### PR TITLE
WIP: add container volume at agent install dir

### DIFF
--- a/deploy/ga/agent/Dockerfile
+++ b/deploy/ga/agent/Dockerfile
@@ -28,6 +28,10 @@ ARG AGENT_HOME=/opt/ibm-ucd/agent
 
 RUN /bin/sh /tmp/agent-setup.sh
 
+#creae volume at agent install location so container state/configuration
+# will persist through restarts or starts with containers of same name
+VOLUME /opt/ibm-ucd/agent
+
 # Set work directory for/and command
 WORKDIR /tmp
 CMD ["sh", "startAgent.sh"]

--- a/deploy/ga/agent/common/startAgent.sh
+++ b/deploy/ga/agent/common/startAgent.sh
@@ -14,20 +14,16 @@
 # limitations under the License.
 
 #Removing the lines from the file
-sed -i '/agent.id/d' /opt/ibm-ucd/agent/conf/agent/installed.properties
 sed -i '/agent.name/d' /opt/ibm-ucd/agent/conf/agent/installed.properties
 
 agentName="agent-"$HOSTNAME
-agentId=""
 if [ $AGENT_NAME ]; then
     agentName=$AGENT_NAME
-    agentId=$AGENT_NAME
 fi
 
 #Setting agent.name to "agent-<hostname_of_container>"
 #Setting the agent.id to "" so that id is auto generated during start
 echo "locked/agent.name="$agentName >> /opt/ibm-ucd/agent/conf/agent/installed.properties
-echo "locked/agent.id="$agentId >> /opt/ibm-ucd/agent/conf/agent/installed.properties
 
 echo "Starting the agent now"
 /opt/ibm-ucd/agent/bin/agent run


### PR DESCRIPTION
This merge is here for pre-approval to submit upstream only. Will be closed and submitted upstream on approval from org leadership.

***

This PR adds a `VOLUME` instruction for the `ucda` docker image at the agent install directory. This allows container state to to persist on the docker storage directory, which will result in the ability to destroy/upgrade/restart containers without losing configurations.

Specifically, this will eliminate the conflicts when new images are started with the same agent hostname (after upgrading the image for example), as long as the volume persists on the configured storage driver.

This provides more flexibility and stability for dockerized agent usage on container orchestration platforms like Swarm or Kubernetes.